### PR TITLE
Add Flask app for exam result calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# pr-fungsergebnis
+# Prüfungsergebnis Rechner
+
+Diese kleine WebApp berechnet, welches Ergebnis in der zweiten Prüfung erreicht werden muss, um ein gewünschtes Gesamt-Ergebnis zu erhalten. Alle Berechnungen werden in einer PostgreSQL-Datenbank gespeichert und können im Admin-Panel eingesehen werden.
+
+## Lokales Starten
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```
+
+Die Anwendung ist anschließend unter `http://localhost:5000` erreichbar. Das Admin-Panel befindet sich unter `http://localhost:5000/admin`.
+
+## Deployment auf Render
+
+1. Dieses Repository zu Render hochladen bzw. mit GitHub verbinden.
+2. Als Startbefehl `python app.py` angeben.
+3. Eine PostgreSQL-Datenbank in Render erstellen und die Verbindungs-URL als Umgebungsvariable `DATABASE_URL` hinterlegen.
+
+Beim ersten Start werden die benötigten Tabellen automatisch erzeugt.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,55 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+import os
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'sqlite:///data.db')
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+# initialize db
+
+# Since render uses Postgres and may require SSL
+if app.config['SQLALCHEMY_DATABASE_URI'].startswith('postgres://'):
+    app.config['SQLALCHEMY_DATABASE_URI'] = app.config['SQLALCHEMY_DATABASE_URI'].replace('postgres://', 'postgresql://', 1)
+
+db = SQLAlchemy(app)
+
+class ExamRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    first_exam = db.Column(db.Float, nullable=False)
+    desired_final = db.Column(db.Float, nullable=False)
+    required_second = db.Column(db.Float, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<ExamRequest {self.id}>'
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    result = None
+    if request.method == 'POST':
+        first_exam = float(request.form['first_exam'])
+        desired_final = float(request.form['desired_final'])
+        required_second = calculate_required_second(first_exam, desired_final)
+        entry = ExamRequest(first_exam=first_exam,
+                            desired_final=desired_final,
+                            required_second=required_second)
+        db.session.add(entry)
+        db.session.commit()
+        result = required_second
+    return render_template('index.html', result=result)
+
+@app.route('/admin')
+def admin():
+    entries = ExamRequest.query.order_by(ExamRequest.timestamp.desc()).all()
+    return render_template('admin.html', entries=entries)
+
+def calculate_required_second(first_exam, desired_final):
+    """Calculate the required second exam percentage."""
+    return max(0.0, min(100.0, (desired_final - 0.4 * first_exam) / 0.6))
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(host='0.0.0.0', port=int(os.getenv('PORT', 5000)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+psycopg2-binary

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <title>Admin Panel</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2em; }
+      table { border-collapse: collapse; width: 100%; }
+      th, td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
+    </style>
+  </head>
+  <body>
+    <h1>Admin Panel</h1>
+    <table>
+      <tr>
+        <th>ID</th>
+        <th>Erste Prüfung (%)</th>
+        <th>Gewünschtes Gesamtergebnis (%)</th>
+        <th>Benötigtes Ergebnis zweite Prüfung (%)</th>
+        <th>Timestamp</th>
+      </tr>
+      {% for e in entries %}
+      <tr>
+        <td>{{ e.id }}</td>
+        <td>{{ e.first_exam }}</td>
+        <td>{{ e.desired_final }}</td>
+        <td>{{ e.required_second|round(2) }}</td>
+        <td>{{ e.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <title>Prüfungsergebnis Rechner</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2em; }
+      .result { margin-top: 1em; font-weight: bold; }
+    </style>
+  </head>
+  <body>
+    <h1>Prüfungsergebnis Rechner</h1>
+    <form method="post">
+      <label for="first_exam">Ergebnis der ersten Prüfung (%):</label>
+      <input type="number" step="0.1" id="first_exam" name="first_exam" required>
+      <br><br>
+      <label for="desired_final">Gewünschtes Gesamtergebnis (%):</label>
+      <input type="range" id="desired_final" name="desired_final" min="0" max="100" value="50" oninput="out.value = desired_final.value">
+      <output name="out" id="out">50</output>%
+      <br><br>
+      <button type="submit">Berechnen</button>
+    </form>
+    {% if result is not none %}
+    <p class="result">Benötigtes Ergebnis in der zweiten Prüfung: {{ result|round(2) }}%</p>
+    {% endif %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build a simple Flask application with SQLAlchemy
- store exam result requests in PostgreSQL
- add admin page to show submitted values
- document local usage and Render deployment instructions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py` *(checked server startup)*

------
https://chatgpt.com/codex/tasks/task_e_6870f071f128832e9b5f86d2c9665683