### PR TITLE
Limit exam inputs to valid range

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,9 @@ def index():
     if request.method == 'POST':
         first_exam = float(request.form['first_exam'])
         desired_final = float(request.form['desired_final'])
+        # clamp inputs to 0-100
+        first_exam = max(0.0, min(100.0, first_exam))
+        desired_final = max(0.0, min(100.0, desired_final))
         required_second = calculate_required_second(first_exam, desired_final)
         entry = ExamRequest(first_exam=first_exam,
                             desired_final=desired_final,

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
     <form method="post" class="mb-3">
       <div class="mb-3">
         <label for="first_exam" class="form-label">Ergebnis der ersten Prüfung (%):</label>
-        <input type="number" step="0.1" id="first_exam" name="first_exam" class="form-control" required>
+        <input type="number" step="0.1" id="first_exam" name="first_exam" class="form-control" min="0" max="100" required>
       </div>
       <div class="mb-3">
         <label for="desired_final" class="form-label">Gewünschtes Gesamtergebnis (%):</label>


### PR DESCRIPTION
## Summary
- enforce 0-100 range for `first_exam` field in the HTML form
- clamp `first_exam` and `desired_final` values server-side

## Testing
- `python -m py_compile app.py`
- *(app run failed: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6870fa7b4f58832e972c06197d792b7b